### PR TITLE
Update TalkBack download info in accessibility.md

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -279,10 +279,7 @@ if (Platform.OS === 'android') {
 
 To enable TalkBack, go to the Settings app on your Android device or emulator. Tap Accessibility, then TalkBack. Toggle the "Use service" switch to enable or disable it.
 
-P.S. Android emulator doesn’t have TalkBack by default. To install it:
-
-1. Download TalkBack file here: https://google-talkback.en.uptodown.com/android
-2. Drag the downloaded `.apk` file into the emulator
+Android emulators don't have TalkBack installed by default. You can install TalkBack on your emulator via the Google Play Store.
 
 You can use the volume key shortcut to toggle TalkBack. To turn on the volume key shortcut, go to the Settings app, then Accessibility. At the top, turn on Volume key shortcut.
 


### PR DESCRIPTION
Downloading TalkBack via a link is not the most safe way to do this, since we don't know how safe the download website is (it's not an official Google site). Downloading from the Google Play Store is the best way to get access to TalkBack on emulators.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
